### PR TITLE
Sudoku logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,20 +5,20 @@ import './App.css';
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+        <header className="App-header">
+            <img src={logo} className="App-logo" alt="logo" />
+            <p>
+                Edit <code>src/App.tsx</code> and save to reload.
+            </p>
+            <a
+                className="App-link"
+                href="https://reactjs.org"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Learn React
+            </a>
+        </header>
     </div>
   );
 }

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -1,28 +1,48 @@
+import Tile from "./tile";
+
 export class Sudoku {
 
-    private grid: number[][];
+    static readonly size: number = 3;
+    private readonly grid: Tile[][];
 
     constructor() {
         this.grid = [];
-        for (let i = 0; i < 9; i++){
-            for (let j = 0; j < 9; j++){
-                this.grid[i][j] = -1;
+        for (let i = 0; i < Sudoku.size; i++){
+            for (let j = 0; j < Sudoku.size; j++){
+                this.grid[i][j] = new Tile();
             }
         }
     }
 
     display(): void {
-        for (let i = 0; i < 9; i++){
-            for (let j = 0; j < 9; j++){
+        for (let i = 0; i < Sudoku.size; i++){
+            for (let j = 0; j < Sudoku.size; j++){
                 console.log(`(${i}, ${j}): ${this.grid[i][j]}`);
             }
         }
     }
 
     insert(i: number, j: number, n: number): boolean {
-
-        this.grid[i][j] = n;
+        console.log(i + j + n);
+        //this.grid[i][j] = n;
         return true;
+    }
+
+    /**
+     * @param i the column coordinate
+     * @param j the row coordinate
+     * @return true if both i and j are within the boundary
+     */
+    validCoordinates(i: number, j: number): boolean {
+        return this.validCoordinate(i) && this.validCoordinate(j);
+    }
+
+    /**
+     * @param c the coordinate to check
+     * @return true if the param c is within the range [0, size^2]
+     */
+    validCoordinate(c: number): boolean {
+        return c >= 0 && c <= Math.pow(Sudoku.size, 2);
     }
 
 }

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -23,9 +23,35 @@ export class Sudoku {
     }
 
     insert(i: number, j: number, n: number): boolean {
-        console.log(i + j + n);
-        //this.grid[i][j] = n;
-        return true;
+        if (!this.validCoordinates(i, j) || !Sudoku.validNumber(n))
+            return false;
+
+        // Tile coordinates
+        const tileI: number = Math.floor(i / Sudoku.size);
+        const tileJ: number = Math.floor(j / Sudoku.size);
+        // coordinates to insert of the Tile
+        const numI: number = i - tileI * Sudoku.size;
+        const numJ: number = j - tileJ * Sudoku.size;
+
+        // check if viable from other tiles
+        // i.e all tiles in the same row / column, that none of those don't have this number in the same tile row / column
+        for (let col = 0; col < Sudoku.size; col++){
+            for (let row = 0; row < Sudoku.size; row++){
+                const inC = col === tileI;
+                const inR = row === tileJ;
+                if (!inC !== !inR) { // equivalent of: inC XOR inR
+                    if (inC)
+                        if (this.grid[col][row].inColumn(numI, n))
+                            return false;
+                    else if (inR)
+                        if (this.grid[col][row].inRow(numI, n))
+                            return false;
+                }
+            }
+        }
+
+        //if this placement doesn't violate any other tile placement rules, attempt to place within the specified tile
+        return this.grid[tileI][tileJ].insert(numI, numJ, n);
     }
 
     /**
@@ -43,6 +69,14 @@ export class Sudoku {
      */
     validCoordinate(c: number): boolean {
         return c >= 0 && c <= Math.pow(Sudoku.size, 2);
+    }
+
+    /**
+     * Checks if the given number is between 1 and size^2 (normally 3^2 = 9)
+     * @param n the number to check
+     */
+    public static validNumber(n: number): boolean {
+        return n > 0 && n <= Math.pow(this.size, 2) ;
     }
 
 }

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -19,12 +19,10 @@ export class Sudoku {
         if (!this.validCoordinates(i, j) || !Sudoku.validNumber(n))
             return false;
 
-        // Tile coordinates
-        const tileI: number = Math.floor(i / Sudoku.size);
-        const tileJ: number = Math.floor(j / Sudoku.size);
-        // coordinates to insert of the Tile
-        const numI: number = i - tileI * Sudoku.size;
-        const numJ: number = j - tileJ * Sudoku.size;
+        const tileI: number = this.tileCoordinate(i);
+        const tileJ: number = this.tileCoordinate(j);
+        const numI: number = this.numberCoordinate(i, tileI);
+        const numJ: number = this.numberCoordinate(j, tileJ);
 
         // check if viable from other tiles
         // i.e all tiles in the same row / column, that none of those don't have this number in the same tile row / column
@@ -71,6 +69,40 @@ export class Sudoku {
      */
     public static validNumber(n: number): boolean {
         return n > 0 && n <= Math.pow(this.size, 2) ;
+    }
+
+    /**
+     * Given a coordinate, determine which tile would hold it
+     * i.e 1,1 resides in tile 0,0.
+     * 8,5 resides in tile 2,1
+     * @param globalC the global coordinate
+     */
+    tileCoordinate(globalC: number): number {
+        return Math.floor(globalC / Sudoku.size);
+    }
+
+    /**
+     * Given the parameters, determine the position within the tile that they refer to
+     * i.e global coordinates 7,6 refers to position 1,0 of tile 2,2
+     * @param globalC the global coordinate
+     * @param tileC the tile coordinate
+     */
+    numberCoordinate(globalC: number, tileC: number): number {
+        return globalC - tileC * Sudoku.size;
+    }
+
+    /**
+     * @TODO Ensure can't delete initial numbers (i.e the numbers that start in the sudoku grid)
+     * Erases a number in the grid, by replacing it with -1
+     * @param i the global column
+     * @param j the global row
+     */
+    eraseNumber(i: number, j: number) {
+        const tileI: number = this.tileCoordinate(i);
+        const tileJ: number = this.tileCoordinate(j);
+        const numI: number = this.numberCoordinate(i, tileI);
+        const numJ: number = this.numberCoordinate(j, tileJ);
+        this.grid[tileI][tileJ].erase(numI, numJ);
     }
 
 }

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -1,0 +1,22 @@
+export class Sudoku {
+
+    private grid: number[][];
+
+    constructor() {
+        this.grid = [];
+        for (let i = 0; i < 9; i++){
+            for (let j = 0; j < 9; j++){
+                this.grid[i][j] = -1;
+            }
+        }
+    }
+
+    display(): void {
+        for (let i = 0; i < 9; i++){
+            for (let j = 0; j < 9; j++){
+                console.log(`(${i}, ${j}): ${this.grid[i][j]}`);
+            }
+        }
+    }
+
+}

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -4,9 +4,11 @@ export class Sudoku {
 
     static readonly size: number = 3;
     grid: Tile[][];
+    public count: number;
 
     constructor() {
         this.grid = [...Array(Sudoku.size)].map(() => Array(Sudoku.size));
+        this.count = 0;
 
         for (let i = 0; i < Sudoku.size; i++){
             for (let j = 0; j < Sudoku.size; j++){
@@ -15,6 +17,13 @@ export class Sudoku {
         }
     }
 
+    /**
+     * inserts a number n, into position (i,j) of the grid
+     * @param i the grid column
+     * @param j the grid row
+     * @param n the number to insert
+     * @return true if the number n was successfully inserted
+     */
     insert(i: number, j: number, n: number): boolean {
         if (!this.validCoordinates(i, j) || !Sudoku.validNumber(n))
             return false;
@@ -43,7 +52,10 @@ export class Sudoku {
         }
 
         //if this placement doesn't violate any other tile placement rules, attempt to place within the specified tile
-        return this.grid[tileI][tileJ].insert(numI, numJ, n);
+        const inserted = this.grid[tileI][tileJ].insert(numI, numJ, n);
+        if (inserted)
+            this.count++;
+        return inserted;
     }
 
     /**
@@ -102,7 +114,16 @@ export class Sudoku {
         const tileJ: number = this.tileCoordinate(j);
         const numI: number = this.numberCoordinate(i, tileI);
         const numJ: number = this.numberCoordinate(j, tileJ);
-        this.grid[tileI][tileJ].erase(numI, numJ);
+        if (this.grid[tileI][tileJ].erase(numI, numJ))
+            this.count--;
+    }
+
+    /**
+     * @return true if the puzzle has been fully completed
+     */
+    isComplete(): boolean {
+        // Since by definition, the puzzle is only complete on a full grid
+        return this.count === Math.pow(Sudoku.size, 4);
     }
 
 }

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -3,21 +3,14 @@ import Tile from "./tile";
 export class Sudoku {
 
     static readonly size: number = 3;
-    private readonly grid: Tile[][];
+    grid: Tile[][];
 
     constructor() {
-        this.grid = [];
+        this.grid = [...Array(Sudoku.size)].map(() => Array(Sudoku.size));
+
         for (let i = 0; i < Sudoku.size; i++){
             for (let j = 0; j < Sudoku.size; j++){
                 this.grid[i][j] = new Tile();
-            }
-        }
-    }
-
-    display(): void {
-        for (let i = 0; i < Sudoku.size; i++){
-            for (let j = 0; j < Sudoku.size; j++){
-                console.log(`(${i}, ${j}): ${this.grid[i][j]}`);
             }
         }
     }
@@ -35,6 +28,7 @@ export class Sudoku {
 
         // check if viable from other tiles
         // i.e all tiles in the same row / column, that none of those don't have this number in the same tile row / column
+        // not scalable with the param `size`
         for (let col = 0; col < Sudoku.size; col++){
             for (let row = 0; row < Sudoku.size; row++){
                 const inC = col === tileI;
@@ -44,7 +38,7 @@ export class Sudoku {
                         if (this.grid[col][row].inColumn(numI, n))
                             return false;
                     else if (inR)
-                        if (this.grid[col][row].inRow(numI, n))
+                        if (this.grid[col][row].inRow(numJ, n))
                             return false;
                 }
             }
@@ -80,3 +74,11 @@ export class Sudoku {
     }
 
 }
+
+const s = new Sudoku();
+s.insert(1,1,7);
+s.insert(6,1,7);
+
+s.grid[0][0].display();
+console.log("-")
+s.grid[2][0].display();

--- a/src/logic/sudoku.ts
+++ b/src/logic/sudoku.ts
@@ -19,4 +19,10 @@ export class Sudoku {
         }
     }
 
+    insert(i: number, j: number, n: number): boolean {
+
+        this.grid[i][j] = n;
+        return true;
+    }
+
 }

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -47,10 +47,12 @@ export default class Tile {
         return true;
     }
 
-    erase(i: number, j: number) {
-        if (!this.validCoordinates(i, j))
-            return;
+    erase(i: number, j: number): boolean {
+        if (!this.validCoordinates(i, j) || this.isEmpty(i, j))
+            return false;
+
         this.grid[i][j] = -1;
+        return true
     }
 
     /**

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -4,23 +4,24 @@
  */
 export class Tile {
 
-    private grid: number[][];
+    readonly size: number = 3;
+    private readonly grid: number[][];
 
     constructor() {
         this.grid = [];
-        for (let i = 0; i < 3; i++) {
-            for (let j = 0; j < 3; j++){
+        for (let i = 0; i < this.size; i++) {
+            for (let j = 0; j < this.size; j++){
                 this.grid[i][j] = -1;
             }
         }
     }
 
     /**
-     * Simply prints out each number, with it's respective coordinates
+     * Simply prints out each number, with its respective coordinates
      */
     display(): void {
-        for (let i = 0; i < 3; i++){
-            for (let j = 0; j < 3; j++){
+        for (let i = 0; i < this.size; i++){
+            for (let j = 0; j < this.size; j++){
                 console.log(`(${i}, ${j}): ${this.grid[i][j]}`);
             }
         }
@@ -30,11 +31,11 @@ export class Tile {
      * Inserts the given number into the grid
      * @param i the column
      * @param j the row
-     * @param n the number in question
+     * @param n the number to insert into the grid
      * @return true if it was inserted, false if it failed
      */
     insert(i: number, j: number, n: number): boolean {
-        if (this.contains(n) || this.grid[i][j] !== -1)
+        if (!this.valid_number(n) || this.contains(n) || !this.is_empty(i, j))
             return false;
 
         this.grid[i][j] = n;
@@ -42,12 +43,21 @@ export class Tile {
     }
 
     /**
-     * @param n the number to check this grid contains
+     * @param i the column
+     * @param j the row
+     * @return true if the position (i,j) is empty
+     */
+    is_empty(i: number, j: number):boolean {
+        return this.grid[i][j] === -1;
+    }
+
+    /**
+     * @param n the number to check for
      * @return true if n is stored within the grid
      */
     contains(n: number): boolean {
-        for (let i = 0; i < 3; i++) {
-            for (let j = 0; j < 3; j++) {
+        for (let i = 0; i < this.size; i++) {
+            for (let j = 0; j < this.size; j++) {
                 if (this.grid[i][j] === n)
                     return true;
             }
@@ -56,11 +66,37 @@ export class Tile {
     }
 
     /**
-     * Checks if the given number is between 1 and 9
+     * @param i the column
+     * @param n the number to check for
+     * @return true if n appears in column j
+     */
+    in_column(i: number, n: number): boolean {
+        for (let j = 0; j < this.size; j++) {
+            if (this.grid[i][j] === n)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param j the row
+     * @param n the number to check for
+     * @return true if n appears in row j
+     */
+    in_row(j: number, n: number): boolean {
+        for (let i = 0; i < this.size; i++) {
+            if (this.grid[i][j] === n)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the given number is between 1 and size^2 (normally 3^2 = 9)
      * @param n the number to check
      */
-    valid(n: number): boolean {
-        return n > 0 && n < 10;
+    valid_number(n: number): boolean {
+        return n > 0 && n < Math.pow(this.size, 2) ;
     }
 
 }

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -1,14 +1,18 @@
 /**
  * A class denoting a subsection of the sudoku grid.
- * Stores 9 positions for numbers to be placed
+ * Stores a number of integers with capacity and range equal to the square of the
+ * number passed in at construction (default 3)
  */
-export class Tile {
+import {Sudoku} from "./sudoku";
 
-    readonly size: number = 3;
+export default class Tile {
+
     private readonly grid: number[][];
+    // add a hashmap to keep track of current numbers stored + coordinates?
 
-    constructor() {
+    constructor(private readonly size: number = Sudoku.size) {
         this.grid = [];
+
         for (let i = 0; i < this.size; i++) {
             for (let j = 0; j < this.size; j++){
                 this.grid[i][j] = -1;
@@ -56,6 +60,7 @@ export class Tile {
      * @return true if n is stored within the grid
      */
     contains(n: number): boolean {
+        // use a hashmap and check instead? Depends on frequency of usage
         for (let i = 0; i < this.size; i++) {
             for (let j = 0; j < this.size; j++) {
                 if (this.grid[i][j] === n)
@@ -89,6 +94,23 @@ export class Tile {
                 return true;
         }
         return false;
+    }
+
+    /**
+     * @param i the column coordinate
+     * @param j the row coordinate
+     * @return true if both i and j are within the boundary
+     */
+    validCoordinates(i: number, j: number): boolean {
+        return this.validCoordinate(i) && this.validCoordinate(j);
+    }
+
+    /**
+     * @param c the coordinate to check
+     * @return true if the param c is within the range [0, size]
+     */
+    validCoordinate(c: number): boolean {
+        return c >= 0 && c <= this.size;
     }
 
     /**

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -12,7 +12,7 @@ export default class Tile {
     // add a hashmap to keep track of current numbers stored + coordinates?
 
     constructor() {
-        this.grid = [];
+        this.grid = this.grid = [...Array(this.size)].map(() => Array(this.size));
 
         for (let i = 0; i < this.size; i++) {
             for (let j = 0; j < this.size; j++){

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -40,11 +40,17 @@ export default class Tile {
      * @return true if it was inserted, false if it failed
      */
     insert(i: number, j: number, n: number): boolean {
-        if (!Sudoku.validNumber(n) || this.contains(n) || !this.isEmpty(i, j))
+        if (!Sudoku.validNumber(n) || this.contains(n) || !this.isEmpty(i, j) || !this.validCoordinates(i, j))
             return false;
 
         this.grid[i][j] = n;
         return true;
+    }
+
+    erase(i: number, j: number) {
+        if (!this.validCoordinates(i, j))
+            return;
+        this.grid[i][j] = -1;
     }
 
     /**

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -7,10 +7,11 @@ import {Sudoku} from "./sudoku";
 
 export default class Tile {
 
+    private readonly size: number = Sudoku.size
     private readonly grid: number[][];
     // add a hashmap to keep track of current numbers stored + coordinates?
 
-    constructor(private readonly size: number = Sudoku.size) {
+    constructor() {
         this.grid = [];
 
         for (let i = 0; i < this.size; i++) {
@@ -39,7 +40,7 @@ export default class Tile {
      * @return true if it was inserted, false if it failed
      */
     insert(i: number, j: number, n: number): boolean {
-        if (!this.validNumber(n) || this.contains(n) || !this.isEmpty(i, j))
+        if (!Sudoku.validNumber(n) || this.contains(n) || !this.isEmpty(i, j))
             return false;
 
         this.grid[i][j] = n;
@@ -111,14 +112,6 @@ export default class Tile {
      */
     validCoordinate(c: number): boolean {
         return c >= 0 && c <= this.size;
-    }
-
-    /**
-     * Checks if the given number is between 1 and size^2 (normally 3^2 = 9)
-     * @param n the number to check
-     */
-    validNumber(n: number): boolean {
-        return n > 0 && n <= Math.pow(this.size, 2) ;
     }
 
 }

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -35,7 +35,7 @@ export class Tile {
      * @return true if it was inserted, false if it failed
      */
     insert(i: number, j: number, n: number): boolean {
-        if (!this.valid_number(n) || this.contains(n) || !this.is_empty(i, j))
+        if (!this.validNumber(n) || this.contains(n) || !this.isEmpty(i, j))
             return false;
 
         this.grid[i][j] = n;
@@ -47,7 +47,7 @@ export class Tile {
      * @param j the row
      * @return true if the position (i,j) is empty
      */
-    is_empty(i: number, j: number):boolean {
+    isEmpty(i: number, j: number):boolean {
         return this.grid[i][j] === -1;
     }
 
@@ -70,7 +70,7 @@ export class Tile {
      * @param n the number to check for
      * @return true if n appears in column j
      */
-    in_column(i: number, n: number): boolean {
+    inColumn(i: number, n: number): boolean {
         for (let j = 0; j < this.size; j++) {
             if (this.grid[i][j] === n)
                 return true;
@@ -83,7 +83,7 @@ export class Tile {
      * @param n the number to check for
      * @return true if n appears in row j
      */
-    in_row(j: number, n: number): boolean {
+    inRow(j: number, n: number): boolean {
         for (let i = 0; i < this.size; i++) {
             if (this.grid[i][j] === n)
                 return true;
@@ -95,8 +95,8 @@ export class Tile {
      * Checks if the given number is between 1 and size^2 (normally 3^2 = 9)
      * @param n the number to check
      */
-    valid_number(n: number): boolean {
-        return n > 0 && n < Math.pow(this.size, 2) ;
+    validNumber(n: number): boolean {
+        return n > 0 && n <= Math.pow(this.size, 2) ;
     }
 
 }

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -1,0 +1,66 @@
+/**
+ * A class denoting a subsection of the sudoku grid.
+ * Stores 9 positions for numbers to be placed
+ */
+export class Tile {
+
+    private grid: number[][];
+
+    constructor() {
+        this.grid = [];
+        for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 3; j++){
+                this.grid[i][j] = -1;
+            }
+        }
+    }
+
+    /**
+     * Simply prints out each number, with it's respective coordinates
+     */
+    display(): void {
+        for (let i = 0; i < 3; i++){
+            for (let j = 0; j < 3; j++){
+                console.log(`(${i}, ${j}): ${this.grid[i][j]}`);
+            }
+        }
+    }
+
+    /**
+     * Inserts the given number into the grid
+     * @param i the column
+     * @param j the row
+     * @param n the number in question
+     * @return true if it was inserted, false if it failed
+     */
+    insert(i: number, j: number, n: number): boolean {
+        if (this.contains(n) || this.grid[i][j] !== -1)
+            return false;
+
+        this.grid[i][j] = n;
+        return true;
+    }
+
+    /**
+     * @param n the number to check this grid contains
+     * @return true if n is stored within the grid
+     */
+    contains(n: number): boolean {
+        for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 3; j++) {
+                if (this.grid[i][j] === n)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the given number is between 1 and 9
+     * @param n the number to check
+     */
+    valid(n: number): boolean {
+        return n > 0 && n < 10;
+    }
+
+}

--- a/src/logic/tile.ts
+++ b/src/logic/tile.ts
@@ -1,13 +1,13 @@
+import Grid from "./grid";
+
 /**
- * A class denoting a subsection of the sudoku grid.
+ * A class denoting a subsection of the sudoku Grid.
  * Stores a number of integers with capacity and range equal to the square of the
  * number passed in at construction (default 3)
  */
-import {Sudoku} from "./sudoku";
-
 export default class Tile {
 
-    private readonly size: number = Sudoku.size
+    private readonly size: number = Grid.size
     private readonly grid: number[][];
     // add a hashmap to keep track of current numbers stored + coordinates?
 
@@ -40,13 +40,19 @@ export default class Tile {
      * @return true if it was inserted, false if it failed
      */
     insert(i: number, j: number, n: number): boolean {
-        if (!Sudoku.validNumber(n) || this.contains(n) || !this.isEmpty(i, j) || !this.validCoordinates(i, j))
+        if (!Grid.validNumber(n) || this.contains(n) || !this.isEmpty(i, j) || !this.validCoordinates(i, j))
             return false;
 
         this.grid[i][j] = n;
         return true;
     }
 
+    /**
+     * removes a number, if it exists, at (i, j)
+     * @param i the tile column
+     * @param j the tile row
+     * @return true if a number was successfully erased
+     */
     erase(i: number, j: number): boolean {
         if (!this.validCoordinates(i, j) || this.isEmpty(i, j))
             return false;
@@ -56,8 +62,8 @@ export default class Tile {
     }
 
     /**
-     * @param i the column
-     * @param j the row
+     * @param i the tile column
+     * @param j the tile row
      * @return true if the position (i,j) is empty
      */
     isEmpty(i: number, j: number):boolean {
@@ -80,7 +86,7 @@ export default class Tile {
     }
 
     /**
-     * @param i the column
+     * @param i the tile column
      * @param n the number to check for
      * @return true if n appears in column j
      */
@@ -93,7 +99,7 @@ export default class Tile {
     }
 
     /**
-     * @param j the row
+     * @param j the tile row
      * @param n the number to check for
      * @return true if n appears in row j
      */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,32 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es5", // Specify ECMAScript target version
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
+    ], // List of library files to be included in the compilation
+    "allowJs": true, // Allow JavaScript files to be compiled
+    "skipLibCheck": true, // Skip type checking of all declaration files
+    "esModuleInterop": true, // Disables namespace imports (import * as fs from "fs") and enables CJS/AMD/UMD style imports (import fs from "fs")
+    "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export
+    "strict": true, // Enable all strict type checking options
+    "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file.
+    "module": "esnext", // Specify module code generation
+    "moduleResolution": "node", // Resolve modules using Node.js style
+    "isolatedModules": true, // Unconditionally emit imports for unresolved files
+    "resolveJsonModule": true, // Include modules imported with .json extension
+    "noEmit": true, // Do not emit output (meaning do not compile code, only perform type checking)
+    "jsx": "react", // Support JSX in .tsx files
+    "sourceMap": true, // Generate corrresponding .map file
+    "declaration": true, // Generate corresponding .d.ts file
+    "noUnusedLocals": true, // Report errors on unused locals
+    "noUnusedParameters": true, // Report errors on unused parameters
+    "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
+    "noFallthroughCasesInSwitch": true // Report errors for fallthrough cases in switch statement
   },
   "include": [
-    "src"
-  ]
+    "src/**/*" // *** The files TypeScript should type check ***
+  ],
+  "exclude": ["node_modules", "build"] // *** The files to not type check ***
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,13 @@
     "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
     "noFallthroughCasesInSwitch": true // Report errors for fallthrough cases in switch statement
   },
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    // same as our --compilerOptions flag and our TS_NODE_COMPILER_OPTIONS environment variable
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "include": [
     "src/**/*" // *** The files TypeScript should type check ***
   ],


### PR DESCRIPTION
Adds the functionality of sudoku game logic from two classes: Grid and Tile. Grid contains logic for the game overall, and has a Tile[][] (normally 3x3) where each Tile holds a number[][] (normally 3x3). Does not include logic for actual puzzles, just the functionality for inserting / removing numbers + validation and verification checking of moves (i.e if they are legal).